### PR TITLE
feat: switch to UAT database image

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+REACTIVE_TAG=0.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 # Temporary files.
 *~
 
-# Docker config.
-.env
-
 # IDEs.
 .idea/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ representative:
 
 - latest Reactive FIX specification.
 - secure token for the Reactive container registry.
-- passwords for database container images.
 
 ## Container Registry
 
@@ -33,32 +32,9 @@ docker login -u <username> -p <token> registry.gitlab.com
 Please contact [support@reactivemarkets.com](mailto:support@reactivemarkets.com) if you unable to
 access the registry with the token provided.
 
-## Container Passwords
-
-The Docker compose file runs several containers, including a database. Databases provided by the
-database container are password protected. Passwords can be specified by setting environment
-variables in a `.env` file alongside the `docker-compose.yml` file.
-
-For example:
-
-```bash
-cat <<EOF >.env
-> MYSQL_ROOT_PASSWORD=xxxx
-> REACTIVE_SQL_PASS=xxxx
-> EOF
-```
-
-Once set, verify that the passwords are correct expanded by the `docker-compose` command:
-
-```bash
-cat .env
-docker-compose config | grep -i pass
-```
-
 ## Container Commands
 
 Run the Docker compose `up` command to create and start all containers:
-
 
 ```bash
 docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,12 @@
 version: "3"
 services:
   mariadb:
-    image: registry.gitlab.com/reactivemarkets/private-registry/mariadb:0.1
+    image: registry.gitlab.com/reactivemarkets/private-registry/mariadb-uat:${REACTIVE_TAG}
     container_name: mariadb
     environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_ROOT_PASSWORD: test
       MYSQL_INITDB_SKIP_TZINFO: 1
+      REACTIVE_SQL_PASS: test
     networks:
       - reactive-net
     ports:
@@ -26,7 +27,7 @@ services:
       - ./conf/redis.conf:/usr/local/etc/redis/redis.conf:ro
 
   refdata:
-    image: registry.gitlab.com/reactivemarkets/private-registry/toolbox-go:0.1
+    image: registry.gitlab.com/reactivemarkets/private-registry/toolbox-go:${REACTIVE_TAG}
     command: refdata
     container_name: refdata
     depends_on:
@@ -36,7 +37,7 @@ services:
       REACTIVE_SQL_TYPE: mysql
       REACTIVE_SQL_HOST: mariadb
       REACTIVE_SQL_USER: reactiveuser
-      REACTIVE_SQL_PASS: ${REACTIVE_SQL_PASS}
+      REACTIVE_SQL_PASS: test
       REACTIVE_SQL_NAME: uatdb
       REACTIVE_SQL_PORT: 3306
       REACTIVE_REDIS_HOST: redis
@@ -46,7 +47,7 @@ services:
     restart: on-failure
 
   revalrates:
-    image: registry.gitlab.com/reactivemarkets/private-registry/toolbox-go:0.1
+    image: registry.gitlab.com/reactivemarkets/private-registry/toolbox-go:${REACTIVE_TAG}
     command: revalrates
     container_name: revalrates
     depends_on:
@@ -59,7 +60,7 @@ services:
     restart: on-failure
 
   crossfix:
-    image: registry.gitlab.com/reactivemarkets/private-registry/matchbox-cpp:0.1
+    image: registry.gitlab.com/reactivemarkets/private-registry/matchbox-cpp:${REACTIVE_TAG}
     entrypoint: /opt/reactivemarkets/matchbox/bin/matchbox-crossfix
     command: ["-f", "/cpp/etc/matchbox-crossfix.conf"]
     container_name: crossfix
@@ -70,7 +71,7 @@ services:
       REACTIVE_SQL_TYPE: mysql
       REACTIVE_SQL_HOST: mariadb
       REACTIVE_SQL_USER: reactiveuser
-      REACTIVE_SQL_PASS: ${REACTIVE_SQL_PASS}
+      REACTIVE_SQL_PASS: test
       REACTIVE_SQL_NAME: uatdb
       REACTIVE_SQL_PORT: 3306
     ipc: host
@@ -84,7 +85,7 @@ services:
       - ./conf/crossfix-fix.conf:/cpp/etc/matchbox-crossfix-fix.conf:ro
 
   clientpricer:
-    image: registry.gitlab.com/reactivemarkets/private-registry/toolbox-go:0.1
+    image: registry.gitlab.com/reactivemarkets/private-registry/toolbox-go:${REACTIVE_TAG}
     command: ["clientpricer", "--config=/go/etc/clientpricer.conf"]
     container_name: clientpricer
     depends_on:


### PR DESCRIPTION
Switch MariaDB container, so that it uses a UAT-specific database image. The reactiveuser password is also now specified when the container is created, so there is no need to specify a password in the environment file.