### PR TITLE
Removing exposed port from mariadb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
       REACTIVE_SQL_PASS: test
     networks:
       - reactive-net
-    ports:
-      - 3306:3306
     restart: on-failure
     volumes:
       - mysql-data:/var/lib/mysql


### PR DESCRIPTION
The exposed port may not be free on the clients machine. No requirement to interact with the database either.